### PR TITLE
Fix handling of blank track titles

### DIFF
--- a/netmdcli/netmdcli.c
+++ b/netmdcli/netmdcli.c
@@ -610,7 +610,7 @@ void print_disc_info(netmd_dev_handle* devh, minidisc* md)
     {
         size = netmd_request_title(devh, i, buffer, 256);
 
-        if(size <= 0)
+        if(size < 0)
         {
             break;
         }


### PR DESCRIPTION
This (if brought upstream to that project) probably fixes both gavinbenda/platinum-md#14 and gavinbenda/platinum-md#12!

The current logic here skips printing JSON data for any tracks with an empty title. The original if statement condition was checking for less-than-zero return codes, which would indicate an error retrieving the information. This reverts the if statement to the original.

I can’t vouch for the contents of this disc, but, it demonstrates the issue and the fix:

Before:
<img width="931" alt="image" src="https://user-images.githubusercontent.com/282113/77137707-3cd63d00-6a2c-11ea-95e1-b52d67f49e5e.png">

After:
<img width="935" alt="image" src="https://user-images.githubusercontent.com/282113/77137715-43fd4b00-6a2c-11ea-8d28-14bc1424803d.png">
