### PR TITLE
Emit JSON using json-c

### DIFF
--- a/build/libjson-c.pri
+++ b/build/libjson-c.pri
@@ -1,0 +1,1 @@
+PKGCONFIG += json-c

--- a/libnetmd/libnetmd.c
+++ b/libnetmd/libnetmd.c
@@ -332,7 +332,6 @@ int netmd_initialize_disc_info(netmd_dev_handle* devh, minidisc* md)
     memset(md->groups, 0, sizeof(struct netmd_group) * md->group_count);
 
     disc_size = request_disc_title(devh, disc, 256);
-    printf("Raw title: %s", disc);
 
     if(disc_size > 0)
     {

--- a/netmdcli/netmdcli.pro
+++ b/netmdcli/netmdcli.pro
@@ -4,6 +4,7 @@ CONFIG += console link_pkgconfig link_prl
 SOURCES += netmdcli.c
 
 include(../libnetmd/use_libnetmd.prl)
+include(../build/libjson-c.pri)
 include(../build/libusb.pri)
 include(../build/installunix.pri)
 include(../build/common.pri)


### PR DESCRIPTION
The current code emits JSON without escaping strings, which means you can run into trouble if, say, a track title contains a backslash.

In this situation, `platinum-md` will then fail to parse the JSON emitted from `netmdcli`, because `netmdcli` does not escape the track name string properly. `platinum-md` will then think `netmdcli` has failed, and return the "Device not detected" screen.

This commit uses the C library `json-c` in `netmdcli` to emit properly-escaped JSON instead of hand `printf()`-ing the output.