### PR TITLE
Fix build of QHiMDTransfer

### DIFF
--- a/devicedb/convert.py
+++ b/devicedb/convert.py
@@ -71,6 +71,7 @@ with open('../qhimdtransfer/linux/etc/udev/60-minidisc.rules', 'w') as fp:
 # Export for libnetmd
 with open('../libnetmd/netmd_dev_ids.h', 'w') as fp:
     print('#include "netmd_dev.h"', file=fp)
+    print('#include <stddef.h>', file=fp)
     print('', file=fp)
     print('static struct netmd_devices const known_devices[] = {', file=fp)
     for vid, pid, name in models_by_mode['netmd']:
@@ -92,6 +93,7 @@ with open('../qhimdtransfer/qhimddetection_dev_ids.h', 'w') as fp:
 
 with open('../qhimdtransfer/qhimddetection_dev_ids.cpp', 'w') as fp:
     print('#include "qhimddetection_dev_ids.h"', file=fp)
+    print('#include <cstddef>', file=fp)
     print('', file=fp)
     print('const char *identify_usb_device(int vid, int pid) {', file=fp)
     for mode, devices in sorted(models_by_mode.items()):

--- a/libnetmd/netmd_dev_ids.h
+++ b/libnetmd/netmd_dev_ids.h
@@ -1,4 +1,5 @@
 #include "netmd_dev.h"
+#include <stddef.h>
 
 static struct netmd_devices const known_devices[] = {
     { 0x04da, 0x23b3, "Panasonic SJ-MR250" },

--- a/qhimdtransfer/qhimddetection_dev_ids.cpp
+++ b/qhimdtransfer/qhimddetection_dev_ids.cpp
@@ -1,4 +1,5 @@
 #include "qhimddetection_dev_ids.h"
+#include <cstddef>
 
 const char *identify_usb_device(int vid, int pid) {
     if (vid == 0x054c && pid == 0x017f) {

--- a/qhimdtransfer/qhimdtransfer.pro
+++ b/qhimdtransfer/qhimdtransfer.pro
@@ -60,6 +60,7 @@ HEADERS += qhimdaboutdialog.h \
     qhimduploaddialog.h \
     qhimdmainwindow.h \
     qhimddetection.h \
+    qhimddetection_dev_ids.h \
     qmdmodel.h \
     qmdtrack.h \
     qmddevice.h
@@ -73,6 +74,7 @@ SOURCES += main.cpp \
     qhimduploaddialog.cpp \
     qhimdmainwindow.cpp \
     qhimddetection.cpp \
+    qhimddetection_dev_ids.cpp \
     qmdmodel.cpp \
     qmdtrack.cpp \
     qmddevice.cpp


### PR DESCRIPTION
That one slipped through when doing the #5 changes. The Qt interface should compile and link properly again now.