### PR TITLE
Fix track duration for tracks longer than 1 hour

### DIFF
--- a/libnetmd/libnetmd.c
+++ b/libnetmd/libnetmd.c
@@ -143,7 +143,10 @@ int netmd_request_track_time(netmd_dev_handle* dev, const uint16_t track, struct
         return 0;
     }
 
-    buffer->minute = bcd_to_proper(time_request + 28, 1) & 0xff;
+    // TODO: Could add "hour" to netmd_track struct later, but all consumers need to be updated then
+    int hours = bcd_to_proper(time_request + 27, 1) & 0xff;
+
+    buffer->minute = (bcd_to_proper(time_request + 28, 1) & 0xff) + hours * 60;
     buffer->second = bcd_to_proper(time_request + 29, 1) & 0xff;
     buffer->tenth = bcd_to_proper(time_request + 30, 1) & 0xff;
     buffer->track = track;


### PR DESCRIPTION
The duration value includes a "hours" field which needs to be read
and added to the minutes returned.

For reference, Web Minidisc / netmd-js properly reads 4 values and
gets the value right (the USB command seems to be slightly different,
but in any case, Web Minidisc shows the proper duration in its UI).

https://github.com/cybercase/netmd-js/blob/edc2401ea1840cecaeea42339b243f37109f8ece/src/netmd-interface.ts#L728